### PR TITLE
Invalid packet in case of already aligned data - don't added End of Options List

### DIFF
--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -235,10 +235,8 @@ impl TcpHeader {
                     }
                 }
             }
-            //write the end & set the new data offset
+            //set the new data offset
             if i > 0 {
-                self.options_buffer[i] = TCP_OPTION_ID_END;
-                i += 1;
                 self._data_offset = (i / 4) as u8 + TCP_MINIMUM_DATA_OFFSET;
                 if i % 4 != 0 {
                     self._data_offset += 1;

--- a/tests/transport/tcp.rs
+++ b/tests/transport/tcp.rs
@@ -216,6 +216,19 @@ proptest! {
         );
     }
 }
+#[test]
+fn set_option_padding() {
+    use TcpOptionElement::*;
+    let mut tcp_header = TcpHeader::default();
+    tcp_header.set_options(&[MaximumSegmentSize(1400), // 4
+                            SelectiveAcknowledgementPermitted, // 2
+                            Timestamp(2661445915, 0), // 10
+                            Nop, // 1
+                            WindowScale(7)]).unwrap(); // 3 
+                            // total 20
+                            // + header 20 = 40 byte
+    assert_eq!(40, tcp_header.header_len());
+}
 
 #[test]
 fn set_options_not_enough_memory_error() {


### PR DESCRIPTION
While patching packet for MSS faced invalid packet length - excessive padding. Added test case for this.