### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/internet/ipv4.rs
+++ b/src/internet/ipv4.rs
@@ -328,7 +328,7 @@ impl Ipv4Header {
             BigEndian::read_u16(&self.source[2..4]),
             BigEndian::read_u16(&self.destination[0..2]),
             BigEndian::read_u16(&self.destination[2..4])
-        ].into_iter().map(|x| u32::from(*x)).sum();
+        ].iter().map(|x| u32::from(*x)).sum();
         let options = self.options();
         for i in 0..(options.len()/2) {
             sum += u32::from( BigEndian::read_u16(&options[i*2..i*2 + 2]) );


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.