### PR TITLE
Randomize `identification` in Ipv4Header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 ]
 
 [dependencies]
+rand = "0.8.5"
 arrayvec = "0.7.2"
 
 [dev-dependencies]

--- a/examples/write_ipv4_udp.rs
+++ b/examples/write_ipv4_udp.rs
@@ -1,5 +1,6 @@
 extern crate etherparse;
 use etherparse::*;
+use std::io::Write;
 
 fn main() {
 
@@ -71,6 +72,8 @@ fn main() {
             udp_payload.len()
         ).unwrap().write(&mut out).unwrap();
     }
+
+    out.write_all(&udp_payload).unwrap();
 
     println!("{:?}", &out);
 }

--- a/src/internet/ipv4.rs
+++ b/src/internet/ipv4.rs
@@ -4,6 +4,8 @@ use std::net::Ipv4Addr;
 use std::fmt::{Debug, Formatter};
 use std::slice::from_raw_parts;
 
+use rand::Rng;
+
 /// IPv4 header without options.
 #[derive(Clone)]
 pub struct Ipv4Header {
@@ -45,7 +47,7 @@ impl Ipv4Header {
             differentiated_services_code_point: 0,
             explicit_congestion_notification: 0,
             payload_len,
-            identification: 0,
+            identification: rand::thread_rng().gen(),
             dont_fragment: true,
             more_fragments: false,
             fragments_offset: 0,


### PR DESCRIPTION
I see that it defaults to zero and that's not good. If you are going to generate fake IP packets, then this feature can detect you
![image](https://user-images.githubusercontent.com/109800286/208290224-5a8e969a-8292-4262-bb5b-7db9d42327ce.png)
