### PR TITLE
Add fn for source and destination on InternetSlice

### DIFF
--- a/src/packet_slicing.rs
+++ b/src/packet_slicing.rs
@@ -16,6 +16,22 @@ impl<'a> InternetSlice<'a> {
             InternetSlice::Ipv6(_, v6_ext) => v6_ext.is_fragmenting_payload(),
         }
     }
+
+    /// Return the source address as an std::net::Ipvddr
+    pub fn source_addr(&self) -> std::net::IpAddr {
+        match self {
+            InternetSlice::Ipv4(v4_hdr, _) => v4_hdr.source_addr().into(),
+            InternetSlice::Ipv6(v6_hdr, _) => v6_hdr.source_addr().into(),
+        }
+    }
+
+    /// Return the destination address as an std::net::IpAddr
+    pub fn destination_addr(&self) -> std::net::IpAddr {
+        match self {
+            InternetSlice::Ipv4(v4_hdr, _) => v4_hdr.destination_addr().into(),
+            InternetSlice::Ipv6(v6_hdr, _) => v6_hdr.destination_addr().into(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/tests/packet_slicing/mod.rs
+++ b/tests/packet_slicing/mod.rs
@@ -102,6 +102,49 @@ mod internet_slice {
             }
         }
     }
+
+    #[test]
+    fn source_dest_addr() {
+        // ipv4
+        {
+            use std::net::*;
+            let mut header: Ipv4Header = Default::default();
+            header.protocol = ip_number::UDP;
+            let buffer = {
+                let mut buffer = Vec::default();
+                header.write(&mut buffer).unwrap();
+                buffer
+            };
+            let ipv4 = Ipv4HeaderSlice::from_slice(&buffer).unwrap();
+            let exts = Ipv4ExtensionsSlice { auth: None };
+            let slice = InternetSlice::Ipv4(ipv4.clone(), exts.clone());
+            assert_eq!(Ipv4Addr::new(0, 0, 0, 0), slice.source_addr());
+        }
+        // ipv6
+        {
+            use std::net::*;
+            let mut header: Ipv6Header = Default::default();
+            header.next_header = ip_number::IPV6_FRAG;
+            let frag_header = Ipv6FragmentHeader{
+                next_header: ip_number::UDP,
+                fragment_offset: 0,
+                more_fragments: false,
+                identification: 0
+            };
+            header.payload_length = frag_header.header_len() as u16;
+            let buffer = {
+                let mut buffer = Vec::default();
+                header.write(&mut buffer).unwrap();
+                frag_header.write(&mut buffer).unwrap();
+                buffer
+            };
+            let ipv6 = Ipv6HeaderSlice::from_slice(&buffer).unwrap();
+            let exts = Ipv6ExtensionsSlice::from_slice(ip_number::IPV6_FRAG, &buffer[header.header_len()..]).unwrap().0;
+            let slice = InternetSlice::Ipv6(ipv6.clone(), exts.clone());
+            // clone & eq
+            assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0 ,0 ,0, 0), slice.destination_addr());
+        }
+    }
 }
 
 mod transport_slice {


### PR DESCRIPTION
This adds two convenience functions. The test might be a bit overkill.