### PR TITLE
Fix examples links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ And for deserialization into the corresponding header structs have a look at:
 ### Packet Builder
 The PacketBuilder struct provides a high level interface for quickly creating network packets. The PacketBuilder will automatically set fields which can be deduced from the content and compositions of the packet itself (e.g. checksums, lengths, ethertype, ip protocol number).
 
-[Example:](examples/write_udp.rs)
+[Example:](etherparse/examples/write_udp.rs)
 ```rust
 use etherparse::PacketBuilder;
 
@@ -148,12 +148,12 @@ let mut result = Vec::<u8>::with_capacity(builder.size(payload.len()));
 builder.write(&mut result, &payload).unwrap();
 ```
 
-There is also an [example for TCP packets](examples/write_tcp.rs) available.
+There is also an [example for TCP packets](etherparse/examples/write_tcp.rs) available.
 
 Check out the [PacketBuilder documentation](https://docs.rs/etherparse/~0/etherparse/struct.PacketBuilder.html) for more informations.
 
 ### Manually serialising each header
-Alternativly it is possible to manually build a packet ([example](examples/write_ipv4_udp.rs)). Generally each struct representing a header has a "write" method that allows it to be serialized. These write methods sometimes automatically calculate checksums and fill them in. In case this is unwanted behavior (e.g. if you want to generate a packet with an invalid checksum), it is also possible to call a "write_raw" method that will simply serialize the data without doing checksum calculations.
+Alternativly it is possible to manually build a packet ([example](etherparse/examples/write_ipv4_udp.rs)). Generally each struct representing a header has a "write" method that allows it to be serialized. These write methods sometimes automatically calculate checksums and fill them in. In case this is unwanted behavior (e.g. if you want to generate a packet with an invalid checksum), it is also possible to call a "write_raw" method that will simply serialize the data without doing checksum calculations.
 
 Read the documentations of the different methods for a more details:
 


### PR DESCRIPTION
Adds `etherparse/` to the front of the examples links in the readme so that they correctly link into the examples subdirectory.