### PR TITLE
Use `core::net` over `std::net`

### DIFF
--- a/etherparse/src/net/ip_slice.rs
+++ b/etherparse/src/net/ip_slice.rs
@@ -40,22 +40,16 @@ impl<'a> IpSlice<'a> {
         }
     }
 
-    /// Return the source address as an std::net::Ipvddr (requires
-    /// crate feature `std`).
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn source_addr(&self) -> std::net::IpAddr {
+    /// Return the source address as an core::net::Ipvddr
+    pub fn source_addr(&self) -> core::net::IpAddr {
         match self {
             IpSlice::Ipv4(s) => s.header().source_addr().into(),
             IpSlice::Ipv6(s) => s.header().source_addr().into(),
         }
     }
 
-    /// Return the destination address as an std::net::IpAddr (requires
-    /// crate feature `std`).
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn destination_addr(&self) -> std::net::IpAddr {
+    /// Return the destination address as an core::net::IpAddr
+    pub fn destination_addr(&self) -> core::net::IpAddr {
         match self {
             IpSlice::Ipv4(s) => s.header().destination_addr().into(),
             IpSlice::Ipv6(s) => s.header().destination_addr().into(),
@@ -335,7 +329,7 @@ mod test {
     use crate::test_gens::*;
     use alloc::{format, vec::Vec};
     use proptest::prelude::*;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn debug_clone_eq() {
@@ -419,7 +413,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn source_addr() {
         // ipv4
@@ -453,7 +446,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn destination_addr() {
         use crate::ip_number::UDP;

--- a/etherparse/src/net/ipv4_header_slice.rs
+++ b/etherparse/src/net/ipv4_header_slice.rs
@@ -1,6 +1,5 @@
 use core::slice::from_raw_parts;
-#[cfg(feature = "std")]
-use std::net::Ipv4Addr;
+use core::net::Ipv4Addr;
 
 use crate::*;
 
@@ -288,9 +287,7 @@ impl<'a> Ipv4HeaderSlice<'a> {
         unsafe { get_unchecked_4_byte_array(self.slice.as_ptr().add(12)) }
     }
 
-    /// Return the ipv4 source address as an std::net::Ipv4Addr
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    /// Return the ipv4 source address as an core::net::Ipv4Addr
     #[inline]
     pub fn source_addr(&self) -> Ipv4Addr {
         Ipv4Addr::from(self.source())
@@ -305,9 +302,7 @@ impl<'a> Ipv4HeaderSlice<'a> {
         unsafe { get_unchecked_4_byte_array(self.slice.as_ptr().add(16)) }
     }
 
-    /// Return the ipv4 destination address as an std::net::Ipv4Addr
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    /// Return the ipv4 destination address as an core::net::Ipv4Addr
     #[inline]
     pub fn destination_addr(&self) -> Ipv4Addr {
         Ipv4Addr::from(self.destination())
@@ -468,6 +463,8 @@ mod test {
     proptest! {
         #[test]
         fn getters(header in ipv4_any()) {
+            use core::net::Ipv4Addr;
+
             let buffer = header.to_bytes();
             let slice = Ipv4HeaderSlice::from_slice(&buffer).unwrap();
 
@@ -488,18 +485,6 @@ mod test {
             assert_eq!(slice.source(), header.source);
             assert_eq!(slice.destination(), header.destination);
             assert_eq!(slice.options(), &header.options[..]);
-        }
-    }
-
-    #[cfg(feature = "std")]
-    proptest! {
-        #[test]
-        fn getters_std(header in ipv4_any()) {
-            use std::net::Ipv4Addr;
-
-            let buffer = header.to_bytes();
-            let slice = Ipv4HeaderSlice::from_slice(&buffer).unwrap();
-
             assert_eq!(slice.source_addr(), Ipv4Addr::from(header.source));
             assert_eq!(slice.destination_addr(), Ipv4Addr::from(header.destination));
         }

--- a/etherparse/src/net/ipv6_header.rs
+++ b/etherparse/src/net/ipv6_header.rs
@@ -288,20 +288,16 @@ impl Ipv6Header {
         writer.write_all(&self.to_bytes())
     }
 
-    /// Return the ipv6 source address as an std::net::Ipv6Addr
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    /// Return the ipv6 source address as an core::net::Ipv6Addr
     #[inline]
-    pub fn source_addr(&self) -> std::net::Ipv6Addr {
-        std::net::Ipv6Addr::from(self.source)
+    pub fn source_addr(&self) -> core::net::Ipv6Addr {
+        core::net::Ipv6Addr::from(self.source)
     }
 
-    /// Return the ipv6 destination address as an std::net::Ipv6Addr
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    /// Return the ipv6 destination address as an core::net::Ipv6Addr
     #[inline]
-    pub fn destination_addr(&self) -> std::net::Ipv6Addr {
-        std::net::Ipv6Addr::from(self.destination)
+    pub fn destination_addr(&self) -> core::net::Ipv6Addr {
+        core::net::Ipv6Addr::from(self.destination)
     }
 
     /// Length of the serialized header in bytes.

--- a/etherparse/src/net/ipv6_header_slice.rs
+++ b/etherparse/src/net/ipv6_header_slice.rs
@@ -147,12 +147,10 @@ impl<'a> Ipv6HeaderSlice<'a> {
         unsafe { get_unchecked_16_byte_array(self.slice.as_ptr().add(8)) }
     }
 
-    /// Return the ipv6 source address as an std::net::Ipv6Addr
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    /// Return the ipv6 source address as an core::net::Ipv6Addr
     #[inline]
-    pub fn source_addr(&self) -> std::net::Ipv6Addr {
-        std::net::Ipv6Addr::from(self.source())
+    pub fn source_addr(&self) -> core::net::Ipv6Addr {
+        core::net::Ipv6Addr::from(self.source())
     }
 
     /// Returns a slice containing the IPv6 destination address.
@@ -165,12 +163,10 @@ impl<'a> Ipv6HeaderSlice<'a> {
         unsafe { get_unchecked_16_byte_array(self.slice.as_ptr().add(24)) }
     }
 
-    /// Return the ipv6 destination address as an std::net::Ipv6Addr
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    /// Return the ipv6 destination address as an core::net::Ipv6Addr
     #[inline]
-    pub fn destination_addr(&self) -> std::net::Ipv6Addr {
-        std::net::Ipv6Addr::from(self.destination())
+    pub fn destination_addr(&self) -> core::net::Ipv6Addr {
+        core::net::Ipv6Addr::from(self.destination())
     }
 
     /// Decode all the fields and copy the results to a Ipv6Header struct
@@ -288,17 +284,8 @@ mod test {
             assert_eq!(actual.hop_limit(), header.hop_limit);
             assert_eq!(actual.source(), header.source);
             assert_eq!(actual.destination(), header.destination);
-        }
-    }
-
-    #[cfg(feature = "std")]
-    proptest! {
-        #[test]
-        fn getters_std(header in ipv6_any()) {
-            let bytes = header.to_bytes();
-            let actual = Ipv6HeaderSlice::from_slice(&bytes).unwrap();
-            assert_eq!(actual.source_addr(), std::net::Ipv6Addr::from(header.source));
-            assert_eq!(actual.destination_addr(), std::net::Ipv6Addr::from(header.destination));
+            assert_eq!(actual.source_addr(), core::net::Ipv6Addr::from(header.source));
+            assert_eq!(actual.destination_addr(), core::net::Ipv6Addr::from(header.destination));
         }
     }
 

--- a/etherparse/src/net/lax_ip_slice.rs
+++ b/etherparse/src/net/lax_ip_slice.rs
@@ -49,22 +49,16 @@ impl<'a> LaxIpSlice<'a> {
         }
     }
 
-    /// Return the source address as an std::net::Ipvddr (requires
-    /// crate feature `std`).
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn source_addr(&self) -> std::net::IpAddr {
+    /// Return the source address as an core::net::Ipvddr.
+    pub fn source_addr(&self) -> core::net::IpAddr {
         match self {
             LaxIpSlice::Ipv4(s) => s.header().source_addr().into(),
             LaxIpSlice::Ipv6(s) => s.header().source_addr().into(),
         }
     }
 
-    /// Return the destination address as an std::net::IpAddr (requires
-    /// crate feature `std`).
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn destination_addr(&self) -> std::net::IpAddr {
+    /// Return the destination address as an core::net::IpAddr.
+    pub fn destination_addr(&self) -> core::net::IpAddr {
         match self {
             LaxIpSlice::Ipv4(s) => s.header().destination_addr().into(),
             LaxIpSlice::Ipv6(s) => s.header().destination_addr().into(),
@@ -443,7 +437,7 @@ mod test {
     use crate::test_gens::*;
     use alloc::{format, vec::Vec};
     use proptest::prelude::*;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn debug_clone_eq() {
@@ -531,7 +525,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn source_addr() {
         // ipv4
@@ -565,7 +558,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn destination_addr() {
         use crate::ip_number::UDP;


### PR DESCRIPTION
Fixes #119 