### PR TITLE
Implement core::error::Error for the error types

### DIFF
--- a/etherparse/ensure_no_std/src/main.rs
+++ b/etherparse/ensure_no_std/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use core::error::Error;
 use core::panic::PanicInfo;
 
 /// This function is called on panic.
@@ -11,5 +12,8 @@ fn panic(_info: &PanicInfo) -> ! {
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    let e = etherparse::err::ip::HeaderError::UnsupportedIpVersion { version_number: 5 };
+    e.source();
+    
     loop {}
 }

--- a/etherparse/ensure_no_std/src/main.rs
+++ b/etherparse/ensure_no_std/src/main.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use core::error::Error;
 use core::panic::PanicInfo;
 
 /// This function is called on panic.
@@ -12,8 +11,5 @@ fn panic(_info: &PanicInfo) -> ! {
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    let e = etherparse::err::ip::HeaderError::UnsupportedIpVersion { version_number: 5 };
-    e.source();
-    
     loop {}
 }

--- a/etherparse/src/defrag/ip_defrag_error.rs
+++ b/etherparse/src/defrag/ip_defrag_error.rs
@@ -42,7 +42,7 @@ impl core::fmt::Display for IpDefragError {
     }
 }
 
-impl std::error::Error for IpDefragError {}
+impl core::error::Error for IpDefragError {}
 
 #[cfg(test)]
 mod tests {
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(UnalignedFragmentPayloadLen {
             offset: IpFragOffset::try_new(0).unwrap(),
             payload_len: 16

--- a/etherparse/src/err/arp/arp_eth_ipv4_from_error.rs
+++ b/etherparse/src/err/arp/arp_eth_ipv4_from_error.rs
@@ -31,10 +31,8 @@ impl core::fmt::Display for ArpEthIpv4FromError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ArpEthIpv4FromError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ArpEthIpv4FromError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/arp/arp_hw_addr_error.rs
+++ b/etherparse/src/err/arp/arp_hw_addr_error.rs
@@ -21,10 +21,8 @@ impl core::fmt::Display for ArpHwAddrError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ArpHwAddrError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ArpHwAddrError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/arp/arp_new_error.rs
+++ b/etherparse/src/err/arp/arp_new_error.rs
@@ -19,10 +19,8 @@ impl core::fmt::Display for ArpNewError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ArpNewError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ArpNewError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/arp/arp_proto_addr_error.rs
+++ b/etherparse/src/err/arp/arp_proto_addr_error.rs
@@ -21,10 +21,8 @@ impl core::fmt::Display for ArpProtoAddrError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ArpProtoAddrError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ArpProtoAddrError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/from_slice_error.rs
+++ b/etherparse/src/err/from_slice_error.rs
@@ -112,10 +112,8 @@ impl core::fmt::Display for FromSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for FromSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for FromSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use FromSliceError::*;
         match self {
             Len(err) => Some(err),
@@ -333,7 +331,7 @@ mod tests {
     use super::{FromSliceError::*, *};
     use core::hash::{Hash, Hasher};
     use std::collections::hash_map::DefaultHasher;
-    use std::error::Error;
+    use core::error::Error;
     use std::format;
 
     #[test]

--- a/etherparse/src/err/io/limited_read_error.rs
+++ b/etherparse/src/err/io/limited_read_error.rs
@@ -53,10 +53,8 @@ impl core::fmt::Display for LimitedReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for LimitedReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for LimitedReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use LimitedReadError::*;
         match self {
             Io(err) => Some(err),
@@ -106,7 +104,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ip/header_error.rs
+++ b/etherparse/src/err/ip/header_error.rs
@@ -27,10 +27,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderError::*;
         match self {
             UnsupportedIpVersion { version_number: _ } => None,

--- a/etherparse/src/err/ip/headers_error.rs
+++ b/etherparse/src/err/ip/headers_error.rs
@@ -24,10 +24,8 @@ impl core::fmt::Display for HeadersError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeadersError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeadersError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeadersError::*;
         match self {
             Ip(err) => Some(err),

--- a/etherparse/src/err/ip/headers_read_error.rs
+++ b/etherparse/src/err/ip/headers_read_error.rs
@@ -68,10 +68,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -126,7 +124,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ip/headers_slice_error.rs
+++ b/etherparse/src/err/ip/headers_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for HeadersSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeadersSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeadersSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeadersSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ip/headers_write_error.rs
+++ b/etherparse/src/err/ip/headers_write_error.rs
@@ -59,10 +59,8 @@ impl core::fmt::Display for HeadersWriteError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeadersWriteError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeadersWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeadersWriteError::*;
         match self {
             Io(ref err) => Some(err),
@@ -77,7 +75,7 @@ mod tests {
     use super::{HeadersWriteError::*, *};
     use crate::*;
     use alloc::format;
-    use std::error::Error;
+    use core::error::Error;
 
     #[test]
     fn io() {

--- a/etherparse/src/err/ip/ip_dscp_unknown_value_error.rs
+++ b/etherparse/src/err/ip/ip_dscp_unknown_value_error.rs
@@ -13,10 +13,8 @@ impl core::fmt::Display for IpDscpUnknownValueError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for IpDscpUnknownValueError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for IpDscpUnknownValueError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ip/lax_header_slice_error.rs
+++ b/etherparse/src/err/ip/lax_header_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for LaxHeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for LaxHeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for LaxHeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use LaxHeaderSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ip/slice_error.rs
+++ b/etherparse/src/err/ip/slice_error.rs
@@ -20,10 +20,8 @@ impl core::fmt::Display for SliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for SliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for SliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use SliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ip_auth/header_error.rs
+++ b/etherparse/src/err/ip_auth/header_error.rs
@@ -17,10 +17,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ip_auth/header_limited_read_error.rs
+++ b/etherparse/src/err/ip_auth/header_limited_read_error.rs
@@ -68,10 +68,8 @@ impl core::fmt::Display for HeaderLimitedReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderLimitedReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderLimitedReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderLimitedReadError::*;
         match self {
             Io(err) => Some(err),
@@ -127,7 +125,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ip_auth/header_read_error.rs
+++ b/etherparse/src/err/ip_auth/header_read_error.rs
@@ -50,10 +50,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -96,7 +94,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ip_auth/header_slice_error.rs
+++ b/etherparse/src/err/ip_auth/header_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for HeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ip_auth/icv_len_error.rs
+++ b/etherparse/src/err/ip_auth/icv_len_error.rs
@@ -25,10 +25,8 @@ impl core::fmt::Display for IcvLenError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for IcvLenError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for IcvLenError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ip_exts/exts_walk_error.rs
+++ b/etherparse/src/err/ip_exts/exts_walk_error.rs
@@ -21,10 +21,8 @@ impl core::fmt::Display for ExtsWalkError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ExtsWalkError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ExtsWalkError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use ExtsWalkError::*;
         match self {
             Ipv4Exts(err) => Some(err),

--- a/etherparse/src/err/ip_exts/header_error.rs
+++ b/etherparse/src/err/ip_exts/header_error.rs
@@ -20,10 +20,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderError::*;
         match self {
             Ipv4Ext(err) => Some(err),

--- a/etherparse/src/err/ip_exts/headers_slice_error.rs
+++ b/etherparse/src/err/ip_exts/headers_slice_error.rs
@@ -42,10 +42,8 @@ impl core::fmt::Display for HeadersSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeadersSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeadersSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeadersSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ipv4/bad_options_len.rs
+++ b/etherparse/src/err/ipv4/bad_options_len.rs
@@ -14,10 +14,8 @@ impl core::fmt::Display for BadOptionsLen {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for BadOptionsLen {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for BadOptionsLen {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ipv4/header_error.rs
+++ b/etherparse/src/err/ipv4/header_error.rs
@@ -24,10 +24,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ipv4/header_read_error.rs
+++ b/etherparse/src/err/ipv4/header_read_error.rs
@@ -50,10 +50,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -96,7 +94,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ipv4/header_slice_error.rs
+++ b/etherparse/src/err/ipv4/header_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for HeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ipv4/slice_error.rs
+++ b/etherparse/src/err/ipv4/slice_error.rs
@@ -24,10 +24,8 @@ impl core::fmt::Display for SliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for SliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for SliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use SliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ipv4_exts/exts_walk_error.rs
+++ b/etherparse/src/err/ipv4_exts/exts_walk_error.rs
@@ -27,10 +27,8 @@ impl core::fmt::Display for ExtsWalkError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ExtsWalkError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ExtsWalkError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use ExtsWalkError::*;
         match self {
             ExtNotReferenced { missing_ext: _ } => None,

--- a/etherparse/src/err/ipv4_exts/header_write_error.rs
+++ b/etherparse/src/err/ipv4_exts/header_write_error.rs
@@ -44,10 +44,8 @@ impl core::fmt::Display for HeaderWriteError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderWriteError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderWriteError::*;
         match self {
             Io(ref err) => Some(err),
@@ -61,7 +59,7 @@ mod tests {
     use super::{ExtsWalkError::*, HeaderWriteError::*};
     use crate::*;
     use alloc::format;
-    use std::error::Error;
+    use core::error::Error;
 
     #[test]
     fn io() {

--- a/etherparse/src/err/ipv6/header_error.rs
+++ b/etherparse/src/err/ipv6/header_error.rs
@@ -17,10 +17,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ipv6/header_read_error.rs
+++ b/etherparse/src/err/ipv6/header_read_error.rs
@@ -50,10 +50,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -96,7 +94,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ipv6/header_slice_error.rs
+++ b/etherparse/src/err/ipv6/header_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for HeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ipv6/slice_error.rs
+++ b/etherparse/src/err/ipv6/slice_error.rs
@@ -24,10 +24,8 @@ impl core::fmt::Display for SliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for SliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for SliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use SliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ipv6_exts/ext_payload_len_error.rs
+++ b/etherparse/src/err/ipv6_exts/ext_payload_len_error.rs
@@ -30,10 +30,8 @@ impl core::fmt::Display for ExtPayloadLenError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ExtPayloadLenError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ExtPayloadLenError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ipv6_exts/exts_walk_error.rs
+++ b/etherparse/src/err/ipv6_exts/exts_walk_error.rs
@@ -28,10 +28,8 @@ impl core::fmt::Display for ExtsWalkError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ExtsWalkError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ExtsWalkError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/ipv6_exts/header_error.rs
+++ b/etherparse/src/err/ipv6_exts/header_error.rs
@@ -20,10 +20,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderError::*;
         match self {
             HopByHopNotAtStart => None,

--- a/etherparse/src/err/ipv6_exts/header_limited_read_error.rs
+++ b/etherparse/src/err/ipv6_exts/header_limited_read_error.rs
@@ -68,10 +68,8 @@ impl core::fmt::Display for HeaderLimitedReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderLimitedReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderLimitedReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderLimitedReadError::*;
         match self {
             Io(err) => Some(err),
@@ -127,7 +125,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ipv6_exts/header_read_error.rs
+++ b/etherparse/src/err/ipv6_exts/header_read_error.rs
@@ -50,10 +50,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -96,7 +94,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/ipv6_exts/header_slice_error.rs
+++ b/etherparse/src/err/ipv6_exts/header_slice_error.rs
@@ -52,10 +52,8 @@ impl core::fmt::Display for HeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/ipv6_exts/header_write_error.rs
+++ b/etherparse/src/err/ipv6_exts/header_write_error.rs
@@ -44,10 +44,8 @@ impl core::fmt::Display for HeaderWriteError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderWriteError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderWriteError::*;
         match self {
             Io(ref err) => Some(err),
@@ -61,7 +59,7 @@ mod tests {
     use super::{ExtsWalkError::*, HeaderWriteError::*};
     use crate::*;
     use alloc::format;
-    use std::error::Error;
+    use core::error::Error;
 
     #[test]
     fn io() {

--- a/etherparse/src/err/len_error.rs
+++ b/etherparse/src/err/len_error.rs
@@ -143,10 +143,8 @@ impl core::fmt::Display for LenError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for LenError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for LenError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/linux_sll/header_error.rs
+++ b/etherparse/src/err/linux_sll/header_error.rs
@@ -22,10 +22,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderError::*;
         match self {
             UnsupportedPacketTypeField { packet_type: _ } => None,

--- a/etherparse/src/err/linux_sll/header_read_error.rs
+++ b/etherparse/src/err/linux_sll/header_read_error.rs
@@ -53,10 +53,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -99,7 +97,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/linux_sll/header_slice_error.rs
+++ b/etherparse/src/err/linux_sll/header_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for HeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/macsec/header_error.rs
+++ b/etherparse/src/err/macsec/header_error.rs
@@ -19,10 +19,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/macsec/header_read_error.rs
+++ b/etherparse/src/err/macsec/header_read_error.rs
@@ -50,10 +50,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -96,7 +94,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/macsec/header_slice_error.rs
+++ b/etherparse/src/err/macsec/header_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for HeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderSliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/net/net_set_next_header_error.rs
+++ b/etherparse/src/err/net/net_set_next_header_error.rs
@@ -17,10 +17,8 @@ impl core::fmt::Display for NetSetNextHeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for NetSetNextHeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for NetSetNextHeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/packet/build_write_error.rs
+++ b/etherparse/src/err/packet/build_write_error.rs
@@ -91,10 +91,8 @@ impl core::fmt::Display for BuildWriteError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for BuildWriteError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for BuildWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use BuildWriteError::*;
         match self {
             Io(ref err) => Some(err),
@@ -112,7 +110,7 @@ mod tests {
     use super::{BuildWriteError::*, *};
     use crate::{err::ValueType, *};
     use alloc::format;
-    use std::error::Error;
+    use core::error::Error;
 
     #[test]
     fn io() {

--- a/etherparse/src/err/packet/slice_error.rs
+++ b/etherparse/src/err/packet/slice_error.rs
@@ -42,10 +42,8 @@ impl core::fmt::Display for SliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for SliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for SliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use SliceError::*;
         match self {
             Len(err) => Some(err),

--- a/etherparse/src/err/packet/transport_checksum_error.rs
+++ b/etherparse/src/err/packet/transport_checksum_error.rs
@@ -21,10 +21,8 @@ impl core::fmt::Display for TransportChecksumError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for TransportChecksumError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for TransportChecksumError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use TransportChecksumError::*;
         match self {
             PayloadLen(err) => Some(err),

--- a/etherparse/src/err/read_error.rs
+++ b/etherparse/src/err/read_error.rs
@@ -125,10 +125,8 @@ impl core::fmt::Display for ReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use ReadError::*;
         match self {
             Io(err) => Some(err),
@@ -473,7 +471,7 @@ mod tests {
         err::{ReadError::*, *},
         LenSource,
     };
-    use std::error::Error;
+    use core::error::Error;
     use std::format;
 
     #[test]

--- a/etherparse/src/err/slice_write_space_error.rs
+++ b/etherparse/src/err/slice_write_space_error.rs
@@ -43,10 +43,8 @@ impl core::fmt::Display for SliceWriteSpaceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for SliceWriteSpaceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for SliceWriteSpaceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/tcp/header_error.rs
+++ b/etherparse/src/err/tcp/header_error.rs
@@ -18,10 +18,8 @@ impl core::fmt::Display for HeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/err/tcp/header_read_error.rs
+++ b/etherparse/src/err/tcp/header_read_error.rs
@@ -50,10 +50,8 @@ impl core::fmt::Display for HeaderReadError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         use HeaderReadError::*;
         match self {
             Io(err) => Some(err),
@@ -96,7 +94,7 @@ mod test {
 
     #[test]
     fn source() {
-        use std::error::Error;
+        use core::error::Error;
         assert!(Io(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "failed to fill whole buffer",

--- a/etherparse/src/err/tcp/header_slice_error.rs
+++ b/etherparse/src/err/tcp/header_slice_error.rs
@@ -34,10 +34,8 @@ impl core::fmt::Display for HeaderSliceError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for HeaderSliceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for HeaderSliceError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             HeaderSliceError::Len(err) => Some(err),
             HeaderSliceError::Content(err) => Some(err),

--- a/etherparse/src/err/value_too_big_error.rs
+++ b/etherparse/src/err/value_too_big_error.rs
@@ -27,13 +27,11 @@ where
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl<T> std::error::Error for ValueTooBigError<T>
+impl<T> core::error::Error for ValueTooBigError<T>
 where
     T: Sized + Clone + Display + Debug + Eq + PartialEq + Hash,
 {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/etherparse/src/transport/tcp_option_read_error.rs
+++ b/etherparse/src/transport/tcp_option_read_error.rs
@@ -17,10 +17,8 @@ pub enum TcpOptionReadError {
     UnknownId(u8),
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for TcpOptionReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for TcpOptionReadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }
@@ -87,7 +85,7 @@ mod test {
             arg_u8_1 in any::<u8>(),
             arg_usize in any::<usize>()
         ) {
-            use std::error::Error;
+            use core::error::Error;
             use crate::TcpOptionReadError::*;
 
             assert!(UnexpectedEndOfSlice{ option_id: arg_u8_0, expected_len: arg_u8_1, actual_len: arg_usize}.source().is_none());

--- a/etherparse/src/transport/tcp_option_write_error.rs
+++ b/etherparse/src/transport/tcp_option_write_error.rs
@@ -9,10 +9,8 @@ pub enum TcpOptionWriteError {
     NotEnoughSpace(usize),
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for TcpOptionWriteError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for TcpOptionWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }
@@ -51,7 +49,7 @@ mod test {
     proptest! {
         #[test]
         fn source(arg_usize in any::<usize>()) {
-            use std::error::Error;
+            use core::error::Error;
             use crate::TcpOptionWriteError::*;
 
             assert!(NotEnoughSpace(arg_usize).source().is_none());


### PR DESCRIPTION
The `std::error::Error` trait also lives in `core`, and there's no reason I'm aware of to not implement it in `no_std` world. This PR modifies all `std::error::Error` impls to instead implement `core::error::Error`, and no longer hides them behind `std` feature.