### PR TITLE
feat: add ICMPv6 neighbour solicitation

### DIFF
--- a/etherparse/src/transport/icmpv6/mod.rs
+++ b/etherparse/src/transport/icmpv6/mod.rs
@@ -10,6 +10,9 @@ pub use parameter_problem_header::*;
 mod time_exceeded_code;
 pub use time_exceeded_code::*;
 
+mod neighbour_discovery;
+pub use neighbour_discovery::*;
+
 /// The maximum number of bytes/octets the ICMPv6 part of a packet can contain.
 ///
 /// The value is determined by the maximum value of the "Upper-Layer Packet Length"

--- a/etherparse/src/transport/icmpv6/neighbour_discovery.rs
+++ b/etherparse/src/transport/icmpv6/neighbour_discovery.rs
@@ -1,0 +1,70 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NeighbourAdverisementHeader {
+    pub router: bool,
+    pub solicited: bool,
+    pub r#override: bool,
+}
+
+const ROUTER_MASK: u8 = 0b10000000;
+const SOLICITED_MASK: u8 = 0b01000000;
+const OVERRIDE_MASK: u8 = 0b00100000;
+
+impl NeighbourAdverisementHeader {
+    pub fn from_bytes(bytes: [u8; 4]) -> Self {
+        let first_byte = bytes[0];
+
+        Self {
+            router: (first_byte & ROUTER_MASK) == ROUTER_MASK,
+            solicited: (first_byte & SOLICITED_MASK) == SOLICITED_MASK,
+            r#override: (first_byte & OVERRIDE_MASK) == OVERRIDE_MASK,
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 4] {
+        let mut first_byte = 0u8;
+
+        if self.router {
+            first_byte |= ROUTER_MASK;
+        }
+        if self.solicited {
+            first_byte |= SOLICITED_MASK;
+        }
+        if self.r#override {
+            first_byte |= OVERRIDE_MASK;
+        }
+
+        [first_byte, 0, 0, 0]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_router_bit_correctly() {
+        assert!(NeighbourAdverisementHeader::from_bytes([0b10000000, 0, 0, 0]).router);
+        assert!(!NeighbourAdverisementHeader::from_bytes([0, 0, 0, 0]).router);
+    }
+
+    #[test]
+    fn reads_solicited_bit_correctly() {
+        assert!(NeighbourAdverisementHeader::from_bytes([0b01000000, 0, 0, 0]).solicited);
+        assert!(!NeighbourAdverisementHeader::from_bytes([0, 0, 0, 0]).solicited);
+    }
+
+    #[test]
+    fn reads_override_bit_correctly() {
+        assert!(NeighbourAdverisementHeader::from_bytes([0b00100000, 0, 0, 0]).r#override);
+        assert!(!NeighbourAdverisementHeader::from_bytes([0, 0, 0, 0]).r#override);
+    }
+
+    #[test]
+    fn reads_combined_bit_correctly() {
+        let header = NeighbourAdverisementHeader::from_bytes([0b11100000, 0, 0, 0]);
+
+        assert!(header.router);
+        assert!(header.solicited);
+        assert!(header.r#override);
+    }
+}

--- a/etherparse/src/transport/icmpv6_header.rs
+++ b/etherparse/src/transport/icmpv6_header.rs
@@ -184,6 +184,10 @@ impl Icmpv6Header {
             ),
             EchoRequest(echo) => return_4u8(TYPE_ECHO_REQUEST, 0, echo.to_bytes()),
             EchoReply(echo) => return_4u8(TYPE_ECHO_REPLY, 0, echo.to_bytes()),
+            NeighbourSoliciation => return_4u8(TYPE_NEIGHBOR_SOLICITATION, 0, [0; 4]),
+            NeighbourAdvertisement(header) => {
+                return_4u8(TYPE_NEIGHBOR_ADVERTISEMENT, 0, header.to_bytes())
+            }
         }
     }
 }

--- a/etherparse/src/transport/icmpv6_slice.rs
+++ b/etherparse/src/transport/icmpv6_slice.rs
@@ -99,6 +99,18 @@ impl<'a> Icmpv6Slice<'a> {
                     return EchoReply(IcmpEchoHeader::from_bytes(self.bytes5to8()));
                 }
             }
+            TYPE_NEIGHBOR_SOLICITATION => {
+                if 0 == self.code_u8() {
+                    return NeighbourSoliciation;
+                }
+            }
+            TYPE_NEIGHBOR_ADVERTISEMENT => {
+                if 0 == self.code_u8() {
+                    return NeighbourAdvertisement(NeighbourAdverisementHeader::from_bytes(
+                        self.bytes5to8(),
+                    ));
+                }
+            }
             _ => {}
         }
         Unknown {


### PR DESCRIPTION
This adds some basic parsing of the ICMPv6 neighbour discovery messages. Parsing the options for these messages is quite complicated so I opted not to do that. They are part of the payload and we also don't parse the payload for e.g. destination unreachable messages.