### PR TITLE
Fix docs saying source instead of destination

### DIFF
--- a/etherparse/src/net/ipv4_header_slice.rs
+++ b/etherparse/src/net/ipv4_header_slice.rs
@@ -293,7 +293,7 @@ impl<'a> Ipv4HeaderSlice<'a> {
         Ipv4Addr::from(self.source())
     }
 
-    /// Returns a slice containing the ipv4 source address.
+    /// Returns a slice containing the ipv4 destination address.
     #[inline]
     pub fn destination(&self) -> [u8; 4] {
         // SAFETY:


### PR DESCRIPTION
This a very minor docs typo I noticed.