### PR TITLE
Enable PacketBuilder in no_std (alloc/slice) while preserving std API

### DIFF
--- a/etherparse/Cargo.toml
+++ b/etherparse/Cargo.toml
@@ -21,7 +21,8 @@ rust-version = "1.83.0"
 
 [features]
 default = ["std"]
-std = ["arrayvec/std"]
+alloc = []
+std = ["alloc", "arrayvec/std"]
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }

--- a/etherparse/src/err/packet/build_slice_write_error.rs
+++ b/etherparse/src/err/packet/build_slice_write_error.rs
@@ -1,0 +1,109 @@
+use crate::err::{ipv4_exts, ipv6_exts, SliceWriteSpaceError, ValueTooBigError};
+
+/// Error while serializing a packet into a byte slice.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum BuildSliceWriteError {
+    /// Not enough space is available in the target slice.
+    /// Contains the minimum required length.
+    Space(usize),
+
+    /// Error if the length of the payload is too
+    /// big to be representable by the length fields.
+    PayloadLen(ValueTooBigError<usize>),
+
+    /// Error if the IPv4 extensions can not be serialized
+    /// because of internal consistency errors.
+    Ipv4Exts(ipv4_exts::ExtsWalkError),
+
+    /// Error if the IPv6 extensions can not be serialized
+    /// because of internal consistency errors.
+    Ipv6Exts(ipv6_exts::ExtsWalkError),
+
+    /// Error if ICMPv6 is packaged in an IPv4 packet (it is undefined
+    /// how to calculate the checksum).
+    Icmpv6InIpv4,
+
+    /// Address size defined in the ARP header does not match the actual size.
+    ArpHeaderNotMatch,
+}
+
+impl From<ValueTooBigError<usize>> for BuildSliceWriteError {
+    fn from(value: ValueTooBigError<usize>) -> Self {
+        BuildSliceWriteError::PayloadLen(value)
+    }
+}
+
+impl From<SliceWriteSpaceError> for BuildSliceWriteError {
+    fn from(value: SliceWriteSpaceError) -> Self {
+        BuildSliceWriteError::Space(value.required_len)
+    }
+}
+
+impl From<super::TransportChecksumError> for BuildSliceWriteError {
+    fn from(value: super::TransportChecksumError) -> Self {
+        match value {
+            super::TransportChecksumError::PayloadLen(err) => BuildSliceWriteError::PayloadLen(err),
+            super::TransportChecksumError::Icmpv6InIpv4 => BuildSliceWriteError::Icmpv6InIpv4,
+        }
+    }
+}
+
+impl From<crate::WriteError<SliceWriteSpaceError, ipv4_exts::ExtsWalkError>>
+    for BuildSliceWriteError
+{
+    fn from(value: crate::WriteError<SliceWriteSpaceError, ipv4_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => BuildSliceWriteError::Space(err.required_len),
+            crate::WriteError::Content(err) => BuildSliceWriteError::Ipv4Exts(err),
+        }
+    }
+}
+
+impl From<crate::WriteError<SliceWriteSpaceError, ipv6_exts::ExtsWalkError>>
+    for BuildSliceWriteError
+{
+    fn from(value: crate::WriteError<SliceWriteSpaceError, ipv6_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => BuildSliceWriteError::Space(err.required_len),
+            crate::WriteError::Content(err) => BuildSliceWriteError::Ipv6Exts(err),
+        }
+    }
+}
+
+impl core::fmt::Display for BuildSliceWriteError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use BuildSliceWriteError::*;
+        match self {
+            Space(required_len) => write!(
+                f,
+                "Not enough space to write packet to slice. Needed {} byte(s).",
+                required_len
+            ),
+            PayloadLen(err) => err.fmt(f),
+            Ipv4Exts(err) => err.fmt(f),
+            Ipv6Exts(err) => err.fmt(f),
+            ArpHeaderNotMatch => write!(
+                f,
+                "address size defined in the ARP header does not match the actual size"
+            ),
+            Icmpv6InIpv4 => write!(
+                f,
+                "Error: ICMPv6 can not be combined with an IPv4 header (checksum can not be calculated)."
+            ),
+        }
+    }
+}
+
+impl core::error::Error for BuildSliceWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        use BuildSliceWriteError::*;
+        match self {
+            Space(_) => None,
+            PayloadLen(err) => Some(err),
+            Ipv4Exts(err) => Some(err),
+            Ipv6Exts(err) => Some(err),
+            Icmpv6InIpv4 => None,
+            ArpHeaderNotMatch => None,
+        }
+    }
+}

--- a/etherparse/src/err/packet/build_vec_write_error.rs
+++ b/etherparse/src/err/packet/build_vec_write_error.rs
@@ -2,6 +2,7 @@ use crate::err::{ipv4_exts, ipv6_exts, ValueTooBigError};
 use core::convert::Infallible;
 
 /// Error while serializing a packet into a [`alloc::vec::Vec`].
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum BuildVecWriteError {
     /// Error if the length of the payload is too

--- a/etherparse/src/err/packet/build_vec_write_error.rs
+++ b/etherparse/src/err/packet/build_vec_write_error.rs
@@ -1,0 +1,96 @@
+use crate::err::{ipv4_exts, ipv6_exts, ValueTooBigError};
+use core::convert::Infallible;
+
+/// Error while serializing a packet into a [`alloc::vec::Vec`].
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum BuildVecWriteError {
+    /// Error if the length of the payload is too
+    /// big to be representable by the length fields.
+    PayloadLen(ValueTooBigError<usize>),
+
+    /// Error if the IPv4 extensions can not be serialized
+    /// because of internal consistency errors.
+    Ipv4Exts(ipv4_exts::ExtsWalkError),
+
+    /// Error if the IPv6 extensions can not be serialized
+    /// because of internal consistency errors.
+    Ipv6Exts(ipv6_exts::ExtsWalkError),
+
+    /// Error if ICMPv6 is packaged in an IPv4 packet (it is undefined
+    /// how to calculate the checksum).
+    Icmpv6InIpv4,
+
+    /// Address size defined in the ARP header does not match the actual size.
+    ArpHeaderNotMatch,
+}
+
+impl From<Infallible> for BuildVecWriteError {
+    fn from(value: Infallible) -> Self {
+        match value {}
+    }
+}
+
+impl From<ValueTooBigError<usize>> for BuildVecWriteError {
+    fn from(value: ValueTooBigError<usize>) -> Self {
+        BuildVecWriteError::PayloadLen(value)
+    }
+}
+
+impl From<super::TransportChecksumError> for BuildVecWriteError {
+    fn from(value: super::TransportChecksumError) -> Self {
+        match value {
+            super::TransportChecksumError::PayloadLen(err) => BuildVecWriteError::PayloadLen(err),
+            super::TransportChecksumError::Icmpv6InIpv4 => BuildVecWriteError::Icmpv6InIpv4,
+        }
+    }
+}
+
+impl From<crate::WriteError<Infallible, ipv4_exts::ExtsWalkError>> for BuildVecWriteError {
+    fn from(value: crate::WriteError<Infallible, ipv4_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => match err {},
+            crate::WriteError::Content(err) => BuildVecWriteError::Ipv4Exts(err),
+        }
+    }
+}
+
+impl From<crate::WriteError<Infallible, ipv6_exts::ExtsWalkError>> for BuildVecWriteError {
+    fn from(value: crate::WriteError<Infallible, ipv6_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => match err {},
+            crate::WriteError::Content(err) => BuildVecWriteError::Ipv6Exts(err),
+        }
+    }
+}
+
+impl core::fmt::Display for BuildVecWriteError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use BuildVecWriteError::*;
+        match self {
+            PayloadLen(err) => err.fmt(f),
+            Ipv4Exts(err) => err.fmt(f),
+            Ipv6Exts(err) => err.fmt(f),
+            ArpHeaderNotMatch => write!(
+                f,
+                "address size defined in the ARP header does not match the actual size"
+            ),
+            Icmpv6InIpv4 => write!(
+                f,
+                "Error: ICMPv6 can not be combined with an IPv4 headers (checksum can not be calculated)."
+            ),
+        }
+    }
+}
+
+impl core::error::Error for BuildVecWriteError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        use BuildVecWriteError::*;
+        match self {
+            PayloadLen(err) => Some(err),
+            Ipv4Exts(err) => Some(err),
+            Ipv6Exts(err) => Some(err),
+            Icmpv6InIpv4 => None,
+            ArpHeaderNotMatch => None,
+        }
+    }
+}

--- a/etherparse/src/err/packet/build_write_error.rs
+++ b/etherparse/src/err/packet/build_write_error.rs
@@ -14,8 +14,7 @@ pub enum BuildWriteError {
     PayloadLen(ValueTooBigError<usize>),
 
     /// Error if the IPv4 extensions can not be serialized
-    /// because of internal consistency errors (i.e. a header
-    /// is never).
+    /// because of internal consistency errors.
     Ipv4Exts(ipv4_exts::ExtsWalkError),
 
     /// Error if the IPv6 extensions can not be serialized
@@ -101,6 +100,50 @@ impl core::error::Error for BuildWriteError {
             Ipv6Exts(err) => Some(err),
             Icmpv6InIpv4 => None,
             ArpHeaderNotMatch => None,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for BuildWriteError {
+    fn from(value: std::io::Error) -> Self {
+        BuildWriteError::Io(value)
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<ValueTooBigError<usize>> for BuildWriteError {
+    fn from(value: ValueTooBigError<usize>) -> Self {
+        BuildWriteError::PayloadLen(value)
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<super::TransportChecksumError> for BuildWriteError {
+    fn from(value: super::TransportChecksumError) -> Self {
+        match value {
+            super::TransportChecksumError::PayloadLen(err) => BuildWriteError::PayloadLen(err),
+            super::TransportChecksumError::Icmpv6InIpv4 => BuildWriteError::Icmpv6InIpv4,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<crate::WriteError<std::io::Error, ipv4_exts::ExtsWalkError>> for BuildWriteError {
+    fn from(value: crate::WriteError<std::io::Error, ipv4_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => BuildWriteError::Io(err),
+            crate::WriteError::Content(err) => BuildWriteError::Ipv4Exts(err),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<crate::WriteError<std::io::Error, ipv6_exts::ExtsWalkError>> for BuildWriteError {
+    fn from(value: crate::WriteError<std::io::Error, ipv6_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => BuildWriteError::Io(err),
+            crate::WriteError::Content(err) => BuildWriteError::Ipv6Exts(err),
         }
     }
 }

--- a/etherparse/src/err/packet/mod.rs
+++ b/etherparse/src/err/packet/mod.rs
@@ -3,6 +3,14 @@ mod build_write_error;
 #[cfg(feature = "std")]
 pub use build_write_error::*;
 
+#[cfg(feature = "alloc")]
+mod build_vec_write_error;
+#[cfg(feature = "alloc")]
+pub use build_vec_write_error::*;
+
+mod build_slice_write_error;
+pub use build_slice_write_error::*;
+
 mod slice_error;
 pub use slice_error::*;
 

--- a/etherparse/src/lib.rs
+++ b/etherparse/src/lib.rs
@@ -303,7 +303,7 @@
 // for docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(test)]
+#[cfg(any(feature = "alloc", test))]
 extern crate alloc;
 #[cfg(test)]
 extern crate proptest;
@@ -343,6 +343,9 @@ mod compositions_tests;
 mod helpers;
 pub(crate) use helpers::*;
 
+mod writer;
+pub(crate) use writer::*;
+
 mod lax_packet_headers;
 pub use lax_packet_headers::*;
 
@@ -358,9 +361,7 @@ pub(crate) use lax_sliced_packet_cursor::*;
 mod len_source;
 pub use len_source::*;
 
-#[cfg(feature = "std")]
 mod packet_builder;
-#[cfg(feature = "std")]
 pub use crate::packet_builder::*;
 
 mod packet_headers;

--- a/etherparse/src/net/ipv4_exts.rs
+++ b/etherparse/src/net/ipv4_exts.rs
@@ -160,6 +160,28 @@ impl Ipv4Extensions {
     }
 
     /// Write the extensions to the writer.
+    pub(crate) fn write_internal<T: CoreWrite + ?Sized>(
+        &self,
+        writer: &mut T,
+        start_ip_number: IpNumber,
+    ) -> Result<(), WriteError<T::Error, err::ipv4_exts::ExtsWalkError>> {
+        use err::ipv4_exts::ExtsWalkError::*;
+        use ip_number::*;
+        match self.auth {
+            Some(ref header) => {
+                if AUTH == start_ip_number {
+                    writer.write_all(&header.to_bytes()).map_err(WriteError::Io)
+                } else {
+                    Err(WriteError::Content(ExtNotReferenced {
+                        missing_ext: IpNumber::AUTHENTICATION_HEADER,
+                    }))
+                }
+            }
+            None => Ok(()),
+        }
+    }
+
+    /// Write the extensions to the writer.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn write<T: std::io::Write + Sized>(
@@ -167,20 +189,11 @@ impl Ipv4Extensions {
         writer: &mut T,
         start_ip_number: IpNumber,
     ) -> Result<(), err::ipv4_exts::HeaderWriteError> {
-        use err::ipv4_exts::{ExtsWalkError::*, HeaderWriteError::*};
-        use ip_number::*;
-        match self.auth {
-            Some(ref header) => {
-                if AUTH == start_ip_number {
-                    header.write(writer).map_err(Io)
-                } else {
-                    Err(Content(ExtNotReferenced {
-                        missing_ext: IpNumber::AUTHENTICATION_HEADER,
-                    }))
-                }
-            }
-            None => Ok(()),
-        }
+        self.write_internal(&mut IoWriter(writer), start_ip_number)
+            .map_err(|err| match err {
+                WriteError::Io(err) => err::ipv4_exts::HeaderWriteError::Io(err),
+                WriteError::Content(err) => err::ipv4_exts::HeaderWriteError::Content(err),
+            })
     }
 
     ///Length of the all present headers in bytes.

--- a/etherparse/src/net/ipv6_exts.rs
+++ b/etherparse/src/net/ipv6_exts.rs
@@ -639,17 +639,13 @@ impl Ipv6Extensions {
     ///
     /// It is required that all next header are correctly set in the headers
     /// and no other ipv6 header extensions follow this header. If this is not
-    /// the case an [`err::ipv6_exts::HeaderWriteError::Content`] error is
-    /// returned.
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn write<T: std::io::Write + Sized>(
+    /// the case a [`err::ipv6_exts::ExtsWalkError`] is returned.
+    pub(crate) fn write_internal<T: CoreWrite + ?Sized>(
         &self,
         writer: &mut T,
         first_header: IpNumber,
-    ) -> Result<(), err::ipv6_exts::HeaderWriteError> {
+    ) -> Result<(), WriteError<T::Error, err::ipv6_exts::ExtsWalkError>> {
         use err::ipv6_exts::ExtsWalkError::*;
-        use err::ipv6_exts::HeaderWriteError::*;
         use ip_number::*;
 
         /// Struct flagging if a header needs to be written.
@@ -681,7 +677,9 @@ impl Ipv6Extensions {
         // check if hop by hop header should be written first
         if IPV6_HOP_BY_HOP == next_header {
             let header = &self.hop_by_hop_options.as_ref().unwrap();
-            header.write(writer).map_err(Io)?;
+            writer
+                .write_all(&header.to_bytes())
+                .map_err(WriteError::Io)?;
             next_header = header.next_header;
             needs_write.hop_by_hop_options = false;
         }
@@ -698,7 +696,7 @@ impl Ipv6Extensions {
                     // by hop if it is not part of this extensions struct.
                     if needs_write.hop_by_hop_options {
                         // the hop by hop header is only allowed at the start
-                        return Err(Content(HopByHopNotAtStart));
+                        return Err(WriteError::Content(HopByHopNotAtStart));
                     } else {
                         break;
                     }
@@ -715,7 +713,9 @@ impl Ipv6Extensions {
                                 .final_destination_options
                                 .as_ref()
                                 .unwrap();
-                            header.write(writer).map_err(Io)?;
+                            writer
+                                .write_all(&header.to_bytes())
+                                .map_err(WriteError::Io)?;
                             next_header = header.next_header;
                             needs_write.final_destination_options = false;
                         } else {
@@ -723,7 +723,9 @@ impl Ipv6Extensions {
                         }
                     } else if needs_write.destination_options {
                         let header = &self.destination_options.as_ref().unwrap();
-                        header.write(writer).map_err(Io)?;
+                        writer
+                            .write_all(&header.to_bytes())
+                            .map_err(WriteError::Io)?;
                         next_header = header.next_header;
                         needs_write.destination_options = false;
                     } else {
@@ -733,7 +735,9 @@ impl Ipv6Extensions {
                 IPV6_ROUTE => {
                     if needs_write.routing {
                         let header = &self.routing.as_ref().unwrap().routing;
-                        header.write(writer).map_err(Io)?;
+                        writer
+                            .write_all(&header.to_bytes())
+                            .map_err(WriteError::Io)?;
                         next_header = header.next_header;
                         needs_write.routing = false;
                         // for destination options
@@ -745,7 +749,9 @@ impl Ipv6Extensions {
                 IPV6_FRAG => {
                     if needs_write.fragment {
                         let header = &self.fragment.as_ref().unwrap();
-                        header.write(writer).map_err(Io)?;
+                        writer
+                            .write_all(&header.to_bytes())
+                            .map_err(WriteError::Io)?;
                         next_header = header.next_header;
                         needs_write.fragment = false;
                     } else {
@@ -755,7 +761,9 @@ impl Ipv6Extensions {
                 AUTH => {
                     if needs_write.auth {
                         let header = &self.auth.as_ref().unwrap();
-                        header.write(writer).map_err(Io)?;
+                        writer
+                            .write_all(&header.to_bytes())
+                            .map_err(WriteError::Io)?;
                         next_header = header.next_header;
                         needs_write.auth = false;
                     } else {
@@ -771,32 +779,54 @@ impl Ipv6Extensions {
 
         // check that all header have been written
         if needs_write.hop_by_hop_options {
-            Err(Content(ExtNotReferenced {
+            Err(WriteError::Content(ExtNotReferenced {
                 missing_ext: IpNumber::IPV6_HEADER_HOP_BY_HOP,
             }))
         } else if needs_write.destination_options {
-            Err(Content(ExtNotReferenced {
+            Err(WriteError::Content(ExtNotReferenced {
                 missing_ext: IpNumber::IPV6_DESTINATION_OPTIONS,
             }))
         } else if needs_write.routing {
-            Err(Content(ExtNotReferenced {
+            Err(WriteError::Content(ExtNotReferenced {
                 missing_ext: IpNumber::IPV6_ROUTE_HEADER,
             }))
         } else if needs_write.fragment {
-            Err(Content(ExtNotReferenced {
+            Err(WriteError::Content(ExtNotReferenced {
                 missing_ext: IpNumber::IPV6_FRAGMENTATION_HEADER,
             }))
         } else if needs_write.auth {
-            Err(Content(ExtNotReferenced {
+            Err(WriteError::Content(ExtNotReferenced {
                 missing_ext: IpNumber::AUTHENTICATION_HEADER,
             }))
         } else if needs_write.final_destination_options {
-            Err(Content(ExtNotReferenced {
+            Err(WriteError::Content(ExtNotReferenced {
                 missing_ext: IpNumber::IPV6_DESTINATION_OPTIONS,
             }))
         } else {
             Ok(())
         }
+    }
+
+    /// Writes the given headers to a writer based on the order defined in
+    /// the next_header fields of the headers and the first header_id
+    /// passed to this function.
+    ///
+    /// It is required that all next header are correctly set in the headers
+    /// and no other ipv6 header extensions follow this header. If this is not
+    /// the case an [`err::ipv6_exts::HeaderWriteError::Content`] error is
+    /// returned.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn write<T: std::io::Write + Sized>(
+        &self,
+        writer: &mut T,
+        first_header: IpNumber,
+    ) -> Result<(), err::ipv6_exts::HeaderWriteError> {
+        self.write_internal(&mut IoWriter(writer), first_header)
+            .map_err(|err| match err {
+                WriteError::Io(err) => err::ipv6_exts::HeaderWriteError::Io(err),
+                WriteError::Content(err) => err::ipv6_exts::HeaderWriteError::Content(err),
+            })
     }
 
     /// Length of the all present headers in bytes.

--- a/etherparse/src/packet_builder.rs
+++ b/etherparse/src/packet_builder.rs
@@ -1,8 +1,58 @@
+use crate::err::packet::BuildSliceWriteError;
+#[cfg(feature = "alloc")]
+use crate::err::packet::BuildVecWriteError;
+#[cfg(feature = "std")]
 use crate::err::packet::BuildWriteError;
 
 use super::*;
 
-use std::{io, marker};
+use core::marker;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+impl From<SliceCoreWriteError> for BuildSliceWriteError {
+    fn from(value: SliceCoreWriteError) -> Self {
+        BuildSliceWriteError::Space(value.required_len)
+    }
+}
+
+impl From<crate::WriteError<SliceCoreWriteError, err::ipv4_exts::ExtsWalkError>>
+    for BuildSliceWriteError
+{
+    fn from(value: crate::WriteError<SliceCoreWriteError, err::ipv4_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => err.into(),
+            crate::WriteError::Content(err) => BuildSliceWriteError::Ipv4Exts(err),
+        }
+    }
+}
+
+impl From<crate::WriteError<SliceCoreWriteError, err::ipv6_exts::ExtsWalkError>>
+    for BuildSliceWriteError
+{
+    fn from(value: crate::WriteError<SliceCoreWriteError, err::ipv6_exts::ExtsWalkError>) -> Self {
+        match value {
+            crate::WriteError::Io(err) => err.into(),
+            crate::WriteError::Content(err) => BuildSliceWriteError::Ipv6Exts(err),
+        }
+    }
+}
+
+fn final_write_to_slice<B>(
+    builder: PacketBuilderStep<B>,
+    buffer: &mut [u8],
+    payload: &[u8],
+) -> Result<usize, BuildSliceWriteError> {
+    let required = final_size(&builder, payload.len());
+    let slice = buffer
+        .get_mut(..required)
+        .ok_or(BuildSliceWriteError::Space(required))?;
+
+    let mut writer = SliceCoreWrite::new(slice);
+    final_write_with_net::<_, _, BuildSliceWriteError>(builder, &mut writer, payload)?;
+    Ok(required)
+}
 
 /// Helper for building packets.
 ///
@@ -100,7 +150,6 @@ use std::{io, marker};
 ///     * [`PacketBuilderStep<Icmpv6Header>::write`]
 ///     * [`PacketBuilderStep<Icmpv6Header>::size`]
 ///
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct PacketBuilder {}
 
 impl PacketBuilder {
@@ -375,13 +424,11 @@ struct PacketImpl {
 }
 
 ///An unfinished packet that is build with the packet builder
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct PacketBuilderStep<LastStep> {
     state: PacketImpl,
     _marker: marker::PhantomData<LastStep>,
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<Ethernet2Header> {
     /// Add an IPv4 header
     ///
@@ -730,7 +777,6 @@ impl PacketBuilderStep<Ethernet2Header> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<LinuxSllHeader> {
     /// Add an ip header (length, protocol/next_header & checksum fields will be overwritten based on the rest of the packet).
     ///
@@ -914,7 +960,6 @@ impl PacketBuilderStep<LinuxSllHeader> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<VlanHeader> {
     ///Add an ip header (length, protocol/next_header & checksum fields will be overwritten based on the rest of the packet).
     ///
@@ -1098,7 +1143,6 @@ impl PacketBuilderStep<VlanHeader> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<IpHeaders> {
     /// Adds an ICMPv4 header of the given [`Icmpv4Type`] to the packet.
     ///
@@ -1636,7 +1680,8 @@ impl PacketBuilderStep<IpHeaders> {
     /// `last_next_header_ip_number` will be set in the last extension header
     /// or if no extension header exists the ip header as the "next header" or
     /// "protocol number".
-    pub fn write<T: io::Write + Sized>(
+    #[cfg(feature = "std")]
+    pub fn write<T: std::io::Write + Sized>(
         mut self,
         writer: &mut T,
         last_next_header_ip_number: IpNumber,
@@ -1651,7 +1696,50 @@ impl PacketBuilderStep<IpHeaders> {
             }
             _ => {}
         }
-        final_write_with_net(self, writer, payload)
+        final_write_with_net::<_, _, BuildWriteError>(self, &mut IoWriter(writer), payload)
+    }
+
+    /// Write all the headers and the payload to a [`Vec<u8>`].
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn write_to_vec(
+        mut self,
+        buffer: &mut Vec<u8>,
+        last_next_header_ip_number: IpNumber,
+        payload: &[u8],
+    ) -> Result<(), BuildVecWriteError> {
+        match &mut (self.state.net_header) {
+            Some(NetHeaders::Ipv4(ref mut ip, ref mut exts)) => {
+                ip.protocol = exts.set_next_headers(last_next_header_ip_number);
+            }
+            Some(NetHeaders::Ipv6(ref mut ip, ref mut exts)) => {
+                ip.next_header = exts.set_next_headers(last_next_header_ip_number);
+            }
+            _ => {}
+        }
+        final_write_with_net::<_, _, BuildVecWriteError>(self, &mut VecWriter(buffer), payload)
+    }
+
+    /// Write all the headers and the payload to a byte slice.
+    ///
+    /// Returns the number of bytes written.
+    pub fn write_to_slice(
+        mut self,
+        buffer: &mut [u8],
+        last_next_header_ip_number: IpNumber,
+        payload: &[u8],
+    ) -> Result<usize, BuildSliceWriteError> {
+        match &mut (self.state.net_header) {
+            Some(NetHeaders::Ipv4(ref mut ip, ref mut exts)) => {
+                ip.protocol = exts.set_next_headers(last_next_header_ip_number);
+            }
+            Some(NetHeaders::Ipv6(ref mut ip, ref mut exts)) => {
+                ip.next_header = exts.set_next_headers(last_next_header_ip_number);
+            }
+            _ => {}
+        }
+
+        final_write_to_slice(self, buffer, payload)
     }
 
     ///Returns the size of the packet when it is serialized
@@ -1660,15 +1748,37 @@ impl PacketBuilderStep<IpHeaders> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<Icmpv4Header> {
     /// Write all the headers and the payload.
-    pub fn write<T: io::Write + Sized>(
+    #[cfg(feature = "std")]
+    pub fn write<T: std::io::Write + Sized>(
         self,
         writer: &mut T,
         payload: &[u8],
     ) -> Result<(), BuildWriteError> {
-        final_write_with_net(self, writer, payload)
+        final_write_with_net::<_, _, BuildWriteError>(self, &mut IoWriter(writer), payload)
+    }
+
+    /// Write all the headers and the payload to a [`Vec<u8>`].
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn write_to_vec(
+        self,
+        buffer: &mut Vec<u8>,
+        payload: &[u8],
+    ) -> Result<(), BuildVecWriteError> {
+        final_write_with_net::<_, _, BuildVecWriteError>(self, &mut VecWriter(buffer), payload)
+    }
+
+    /// Write all the headers and the payload to a byte slice.
+    ///
+    /// Returns the number of bytes written.
+    pub fn write_to_slice(
+        self,
+        buffer: &mut [u8],
+        payload: &[u8],
+    ) -> Result<usize, BuildSliceWriteError> {
+        final_write_to_slice(self, buffer, payload)
     }
 
     /// Returns the size of the packet when it is serialized
@@ -1677,15 +1787,37 @@ impl PacketBuilderStep<Icmpv4Header> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<Icmpv6Header> {
     ///Write all the headers and the payload.
-    pub fn write<T: io::Write + Sized>(
+    #[cfg(feature = "std")]
+    pub fn write<T: std::io::Write + Sized>(
         self,
         writer: &mut T,
         payload: &[u8],
     ) -> Result<(), BuildWriteError> {
-        final_write_with_net(self, writer, payload)
+        final_write_with_net::<_, _, BuildWriteError>(self, &mut IoWriter(writer), payload)
+    }
+
+    /// Write all the headers and the payload to a [`Vec<u8>`].
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn write_to_vec(
+        self,
+        buffer: &mut Vec<u8>,
+        payload: &[u8],
+    ) -> Result<(), BuildVecWriteError> {
+        final_write_with_net::<_, _, BuildVecWriteError>(self, &mut VecWriter(buffer), payload)
+    }
+
+    /// Write all the headers and the payload to a byte slice.
+    ///
+    /// Returns the number of bytes written.
+    pub fn write_to_slice(
+        self,
+        buffer: &mut [u8],
+        payload: &[u8],
+    ) -> Result<usize, BuildSliceWriteError> {
+        final_write_to_slice(self, buffer, payload)
     }
 
     ///Returns the size of the packet when it is serialized
@@ -1694,15 +1826,37 @@ impl PacketBuilderStep<Icmpv6Header> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<UdpHeader> {
     ///Write all the headers and the payload.
-    pub fn write<T: io::Write + Sized>(
+    #[cfg(feature = "std")]
+    pub fn write<T: std::io::Write + Sized>(
         self,
         writer: &mut T,
         payload: &[u8],
     ) -> Result<(), BuildWriteError> {
-        final_write_with_net(self, writer, payload)
+        final_write_with_net::<_, _, BuildWriteError>(self, &mut IoWriter(writer), payload)
+    }
+
+    /// Write all the headers and the payload to a [`Vec<u8>`].
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn write_to_vec(
+        self,
+        buffer: &mut Vec<u8>,
+        payload: &[u8],
+    ) -> Result<(), BuildVecWriteError> {
+        final_write_with_net::<_, _, BuildVecWriteError>(self, &mut VecWriter(buffer), payload)
+    }
+
+    /// Write all the headers and the payload to a byte slice.
+    ///
+    /// Returns the number of bytes written.
+    pub fn write_to_slice(
+        self,
+        buffer: &mut [u8],
+        payload: &[u8],
+    ) -> Result<usize, BuildSliceWriteError> {
+        final_write_to_slice(self, buffer, payload)
     }
 
     ///Returns the size of the packet when it is serialized
@@ -1711,7 +1865,6 @@ impl PacketBuilderStep<UdpHeader> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<TcpHeader> {
     ///Set ns flag (ECN-nonce - concealment protection; experimental: see RFC 3540)
     pub fn ns(mut self) -> PacketBuilderStep<TcpHeader> {
@@ -1858,12 +2011,35 @@ impl PacketBuilderStep<TcpHeader> {
     }
 
     ///Write all the headers and the payload.
-    pub fn write<T: io::Write + Sized>(
+    #[cfg(feature = "std")]
+    pub fn write<T: std::io::Write + Sized>(
         self,
         writer: &mut T,
         payload: &[u8],
     ) -> Result<(), BuildWriteError> {
-        final_write_with_net(self, writer, payload)
+        final_write_with_net::<_, _, BuildWriteError>(self, &mut IoWriter(writer), payload)
+    }
+
+    /// Write all the headers and the payload to a [`Vec<u8>`].
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn write_to_vec(
+        self,
+        buffer: &mut Vec<u8>,
+        payload: &[u8],
+    ) -> Result<(), BuildVecWriteError> {
+        final_write_with_net::<_, _, BuildVecWriteError>(self, &mut VecWriter(buffer), payload)
+    }
+
+    /// Write all the headers and the payload to a byte slice.
+    ///
+    /// Returns the number of bytes written.
+    pub fn write_to_slice(
+        self,
+        buffer: &mut [u8],
+        payload: &[u8],
+    ) -> Result<usize, BuildSliceWriteError> {
+        final_write_to_slice(self, buffer, payload)
     }
 
     ///Returns the size of the packet when it is serialized
@@ -1872,11 +2048,26 @@ impl PacketBuilderStep<TcpHeader> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl PacketBuilderStep<ArpPacket> {
-    pub fn write<T: io::Write + Sized>(self, writer: &mut T) -> Result<(), BuildWriteError> {
-        final_write_with_net(self, writer, &[])?;
+    #[cfg(feature = "std")]
+    pub fn write<T: std::io::Write + Sized>(self, writer: &mut T) -> Result<(), BuildWriteError> {
+        final_write_with_net::<_, _, BuildWriteError>(self, &mut IoWriter(writer), &[])?;
         Ok(())
+    }
+
+    /// Write all the headers to a [`Vec<u8>`].
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn write_to_vec(self, buffer: &mut Vec<u8>) -> Result<(), BuildVecWriteError> {
+        final_write_with_net::<_, _, BuildVecWriteError>(self, &mut VecWriter(buffer), &[])?;
+        Ok(())
+    }
+
+    /// Write all the headers to a byte slice.
+    ///
+    /// Returns the number of bytes written.
+    pub fn write_to_slice(self, buffer: &mut [u8]) -> Result<usize, BuildSliceWriteError> {
+        final_write_to_slice(self, buffer, &[])
     }
 
     pub fn size(&self) -> usize {
@@ -1885,12 +2076,19 @@ impl PacketBuilderStep<ArpPacket> {
 }
 
 /// Write all the headers and the payload.
-fn final_write_with_net<T: io::Write + Sized, B>(
+fn final_write_with_net<W, B, E>(
     builder: PacketBuilderStep<B>,
-    writer: &mut T,
+    writer: &mut W,
     payload: &[u8],
-) -> Result<(), BuildWriteError> {
-    use BuildWriteError::*;
+) -> Result<(), E>
+where
+    W: CoreWrite + Sized,
+    E: From<W::Error>
+        + From<crate::WriteError<W::Error, err::ipv4_exts::ExtsWalkError>>
+        + From<crate::WriteError<W::Error, err::ipv6_exts::ExtsWalkError>>
+        + From<err::ValueTooBigError<usize>>
+        + From<err::packet::TransportChecksumError>,
+{
     use NetHeaders::*;
 
     // unpack builder (makes things easier with the borrow checker)
@@ -1921,7 +2119,7 @@ fn final_write_with_net<T: io::Write + Sized, B>(
                         None => net_ether_type,
                     }
                 };
-                eth.write(writer).map_err(Io)?;
+                writer.write_all(&eth.to_bytes()).map_err(E::from)?;
             }
             LinkHeader::LinuxSll(mut linux_sll) => {
                 // Assumes that next layers are ether based. If more types of
@@ -1929,7 +2127,7 @@ fn final_write_with_net<T: io::Write + Sized, B>(
                 debug_assert_eq!(linux_sll.arp_hrd_type, ArpHardwareId::ETHERNET);
 
                 linux_sll.protocol_type.change_value(net_ether_type.into());
-                linux_sll.write(writer).map_err(Io)?;
+                writer.write_all(&linux_sll.to_bytes()).map_err(E::from)?;
             }
         }
     }
@@ -1941,15 +2139,15 @@ fn final_write_with_net<T: io::Write + Sized, B>(
             //set ether types
             value.ether_type = net_ether_type;
             //serialize
-            value.write(writer).map_err(Io)?;
+            writer.write_all(&value.to_bytes()).map_err(E::from)?;
         }
         Some(Double(mut value)) => {
             //set ether types
             value.outer.ether_type = ether_type::VLAN_TAGGED_FRAME;
             value.inner.ether_type = net_ether_type;
             //serialize
-            value.outer.write(writer).map_err(Io)?;
-            value.inner.write(writer).map_err(Io)?;
+            writer.write_all(&value.outer.to_bytes()).map_err(E::from)?;
+            writer.write_all(&value.inner.to_bytes()).map_err(E::from)?;
         }
         None => {}
     }
@@ -1976,7 +2174,7 @@ fn final_write_with_net<T: io::Write + Sized, B>(
                     + transport.as_ref().map(|v| v.header_len()).unwrap_or(0)
                     + payload.len(),
             )
-            .map_err(PayloadLen)?;
+            .map_err(E::from)?;
 
             if let Some(transport) = &transport {
                 ip.protocol = ip_exts.set_next_headers(match &transport {
@@ -1988,24 +2186,15 @@ fn final_write_with_net<T: io::Write + Sized, B>(
             }
 
             // write ip header & extensions
-            ip.write(writer).map_err(Io)?;
-            ip_exts.write(writer, ip.protocol).map_err(|err| {
-                use err::ipv4_exts::HeaderWriteError as I;
-                match err {
-                    I::Io(err) => Io(err),
-                    I::Content(err) => Ipv4Exts(err),
-                }
-            })?;
+            ip.header_checksum = ip.calc_header_checksum();
+            writer.write_all(&ip.to_bytes()).map_err(E::from)?;
+            ip_exts
+                .write_internal(writer, ip.protocol)
+                .map_err(E::from)?;
 
             // update the transport layer checksum
             if let Some(t) = &mut transport {
-                t.update_checksum_ipv4(&ip, payload).map_err(|err| {
-                    use err::packet::TransportChecksumError as I;
-                    match err {
-                        I::PayloadLen(err) => PayloadLen(err),
-                        I::Icmpv6InIpv4 => Icmpv6InIpv4,
-                    }
-                })?;
+                t.update_checksum_ipv4(&ip, payload).map_err(E::from)?;
             }
         }
         Some(NetHeaders::Ipv6(mut ip, mut ip_exts)) => {
@@ -2015,7 +2204,7 @@ fn final_write_with_net<T: io::Write + Sized, B>(
                     + transport.as_ref().map(|v| v.header_len()).unwrap_or(0)
                     + payload.len(),
             )
-            .map_err(PayloadLen)?;
+            .map_err(E::from)?;
 
             if let Some(transport) = &transport {
                 ip.next_header = ip_exts.set_next_headers(match &transport {
@@ -2027,37 +2216,41 @@ fn final_write_with_net<T: io::Write + Sized, B>(
             }
 
             // write ip header & extensions
-            ip.write(writer).map_err(Io)?;
-            ip_exts.write(writer, ip.next_header).map_err(|err| {
-                use err::ipv6_exts::HeaderWriteError as I;
-                match err {
-                    I::Io(err) => Io(err),
-                    I::Content(err) => Ipv6Exts(err),
-                }
-            })?;
+            writer.write_all(&ip.to_bytes()).map_err(E::from)?;
+            ip_exts
+                .write_internal(writer, ip.next_header)
+                .map_err(E::from)?;
 
             // update the transport layer checksum
             if let Some(t) = &mut transport {
-                t.update_checksum_ipv6(&ip, payload).map_err(PayloadLen)?;
+                t.update_checksum_ipv6(&ip, payload).map_err(E::from)?;
             }
         }
         Some(NetHeaders::Arp(arp)) => {
-            writer.write_all(&arp.to_bytes()).map_err(Io)?;
+            writer.write_all(&arp.to_bytes()).map_err(E::from)?;
         }
         None => {}
     }
 
     // write transport header
     if let Some(transport) = transport {
-        transport.write(writer).map_err(Io)?;
+        match transport {
+            TransportHeader::Icmpv4(value) => {
+                writer.write_all(&value.to_bytes()).map_err(E::from)?
+            }
+            TransportHeader::Icmpv6(value) => {
+                writer.write_all(&value.to_bytes()).map_err(E::from)?
+            }
+            TransportHeader::Udp(value) => writer.write_all(&value.to_bytes()).map_err(E::from)?,
+            TransportHeader::Tcp(value) => writer.write_all(&value.to_bytes()).map_err(E::from)?,
+        }
     }
 
     // and finally the payload
-    writer.write_all(payload).map_err(Io)?;
+    writer.write_all(payload).map_err(E::from)?;
 
     Ok(())
 }
-
 ///Returns the size of the packet when it is serialized
 fn final_size<B>(builder: &PacketBuilderStep<B>, payload_size: usize) -> usize {
     use crate::NetHeaders::*;
@@ -2111,7 +2304,7 @@ mod white_box_tests {
     #[should_panic]
     fn final_write_panic_missing_ip() {
         let mut writer = Vec::new();
-        final_write_with_net(
+        final_write_with_net::<_, _, BuildVecWriteError>(
             PacketBuilderStep::<UdpHeader> {
                 state: PacketImpl {
                     link_header: None,
@@ -2121,7 +2314,7 @@ mod white_box_tests {
                 },
                 _marker: marker::PhantomData::<UdpHeader> {},
             },
-            &mut writer,
+            &mut VecWriter(&mut writer),
             &[],
         )
         .unwrap();
@@ -2294,6 +2487,82 @@ mod test {
         let mut actual_payload: [u8; 4] = [0; 4];
         cursor.read_exact(&mut actual_payload).unwrap();
         assert_eq!(actual_payload, in_payload);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn write_to_vec_empty() {
+        let payload = [1, 2, 3, 4];
+        let mut written = Vec::new();
+        let builder = PacketBuilder::ipv4([13, 14, 15, 16], [17, 18, 19, 20], 21).udp(22, 23);
+        let expected_len = builder.size(payload.len());
+
+        builder.write_to_vec(&mut written, &payload).unwrap();
+
+        assert_eq!(written.len(), expected_len);
+
+        let mut expected = Vec::new();
+        PacketBuilder::ipv4([13, 14, 15, 16], [17, 18, 19, 20], 21)
+            .udp(22, 23)
+            .write(&mut expected, &payload)
+            .unwrap();
+        assert_eq!(written, expected);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn write_to_vec_with_existing_content() {
+        let payload = [1, 2, 3, 4];
+        let prefix = vec![0xaa, 0xbb, 0xcc];
+        let mut written = prefix.clone();
+
+        PacketBuilder::ipv4([13, 14, 15, 16], [17, 18, 19, 20], 21)
+            .udp(22, 23)
+            .write_to_vec(&mut written, &payload)
+            .unwrap();
+
+        assert_eq!(&written[..prefix.len()], prefix.as_slice());
+
+        let mut expected_packet = Vec::new();
+        PacketBuilder::ipv4([13, 14, 15, 16], [17, 18, 19, 20], 21)
+            .udp(22, 23)
+            .write(&mut expected_packet, &payload)
+            .unwrap();
+        assert_eq!(&written[prefix.len()..], expected_packet.as_slice());
+    }
+
+    #[test]
+    fn write_to_slice_success() {
+        let payload = [1, 2, 3, 4];
+
+        let mut expected = Vec::new();
+        PacketBuilder::ipv4([13, 14, 15, 16], [17, 18, 19, 20], 21)
+            .udp(22, 23)
+            .write(&mut expected, &payload)
+            .unwrap();
+        let required = expected.len();
+
+        let mut buffer = vec![0x55; required + 4];
+        let written = PacketBuilder::ipv4([13, 14, 15, 16], [17, 18, 19, 20], 21)
+            .udp(22, 23)
+            .write_to_slice(&mut buffer, &payload)
+            .unwrap();
+
+        assert_eq!(written, required);
+        assert_eq!(&buffer[..written], expected.as_slice());
+        assert_eq!(&buffer[written..], &[0x55, 0x55, 0x55, 0x55]);
+    }
+
+    #[test]
+    fn write_to_slice_too_small() {
+        let payload = [1, 2, 3, 4];
+        let builder = PacketBuilder::ipv4([13, 14, 15, 16], [17, 18, 19, 20], 21).udp(22, 23);
+        let required = builder.size(payload.len());
+        let mut buffer = vec![0u8; required - 1];
+
+        let actual = builder.write_to_slice(&mut buffer, &payload).unwrap_err();
+        let expected = BuildSliceWriteError::Space(required);
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/etherparse/src/writer.rs
+++ b/etherparse/src/writer.rs
@@ -1,0 +1,85 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
+use core::convert::Infallible;
+
+/// Internal writer abstraction used to share serialization code between
+/// `std` and `no_std` code paths.
+pub(crate) trait CoreWrite {
+    type Error;
+
+    fn write_all(&mut self, slice: &[u8]) -> Result<(), Self::Error>;
+}
+
+/// Internal generic write error that separates transport errors (`Io`) from
+/// semantic/content errors (`Content`).
+pub(crate) enum WriteError<IO, Content> {
+    Io(IO),
+    Content(Content),
+}
+
+#[cfg(feature = "std")]
+pub(crate) struct IoWriter<'a, T: std::io::Write + ?Sized>(pub(crate) &'a mut T);
+
+#[cfg(feature = "alloc")]
+pub(crate) struct VecWriter<'a>(pub(crate) &'a mut Vec<u8>);
+
+pub(crate) struct SliceCoreWrite<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub(crate) struct SliceCoreWriteError {
+    pub(crate) required_len: usize,
+    pub(crate) len: usize,
+}
+
+impl<'a> SliceCoreWrite<'a> {
+    #[inline]
+    pub(crate) fn new(buf: &'a mut [u8]) -> Self {
+        SliceCoreWrite { buf, pos: 0 }
+    }
+}
+
+impl CoreWrite for SliceCoreWrite<'_> {
+    type Error = SliceCoreWriteError;
+
+    #[inline]
+    fn write_all(&mut self, slice: &[u8]) -> Result<(), Self::Error> {
+        let buf_len = self.buf.len();
+
+        let required_len = self.pos.saturating_add(slice.len());
+        self.buf
+            .get_mut(self.pos..)
+            .and_then(|tail| tail.get_mut(..slice.len()))
+            .ok_or(SliceCoreWriteError {
+                required_len,
+                len: buf_len,
+            })?
+            .copy_from_slice(slice);
+        self.pos = required_len;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: std::io::Write + ?Sized> CoreWrite for IoWriter<'_, T> {
+    type Error = std::io::Error;
+
+    #[inline]
+    fn write_all(&mut self, slice: &[u8]) -> Result<(), Self::Error> {
+        std::io::Write::write_all(self.0, slice)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl CoreWrite for VecWriter<'_> {
+    type Error = Infallible;
+
+    #[inline]
+    fn write_all(&mut self, slice: &[u8]) -> Result<(), Self::Error> {
+        self.0.extend_from_slice(slice);
+        Ok(())
+    }
+}


### PR DESCRIPTION
PacketBuilder serialization is split from std::io::Write so packet building works in no_std environments while keeping std behavior intact.

Key changes
- Introduce an internal writer abstraction (`CoreWrite`) and internal `WriteError<IO, Content>` in `src/writer.rs`.
- Add an explicit `alloc` feature and make `std` depend on `alloc`.
- Make `PacketBuilder` available without `std`.
- Keep std `write(...) -> BuildWriteError` API, with `BuildWriteError` remaining std-only.
- Add no_std-capable write APIs:
  - `write_to_vec` (alloc) with `BuildVecWriteError`
  - `write_to_slice` (no alloc) with `BuildSliceWriteError`
- Refactor IPv4/IPv6 extension writing through shared internal methods used by both std and no_std paths.
- Add docsrs cfg annotations for alloc-only APIs.
- Add focused tests for vec and slice write paths:
  - write to empty vec
  - write to pre-populated vec
  - write to slice success path
  - write to slice too-small error path

Compatibility
- std users keep existing `PacketBuilder::write` behavior.
- no_std users gain packet serialization through vec/slice writers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Write packets directly to slices or vectors via new write_to_slice() and write_to_vec() APIs
  - Added an alloc feature to enable packet building without std
  - New, clearer error types for slice/vec/std packet serialization

* **Bug Fixes / Reliability**
  - Improved serialization reliability and error reporting for extension/length/space failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->