### PR TITLE
Fix bug in UDP checksum test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
         build:
         - linux-stable
         - linux-32bit-stable
+        - linux-s390x-stable
         - linux-beta
         - linux-nightly
         - macos-stable
@@ -28,6 +29,10 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: i686-unknown-linux-gnu
+        - build: linux-s390x-stable
+          os: ubuntu-latest
+          rust: stable
+          target: s390x-unknown-linux-gnu
         - build: linux-beta
           os: ubuntu-latest
           rust: beta

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         build:
         - linux-stable
         - linux-32bit-stable
-        - linux-s390x-stable
+        - linux-ppc64-stable
         - linux-beta
         - linux-nightly
         - macos-stable
@@ -29,10 +29,12 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: i686-unknown-linux-gnu
-        - build: linux-s390x-stable
+        # big endian target (catches endianness bugs, e.g. in checksum calc).
+        # powerpc64 is 64-bit big endian and emulates faster under QEMU than s390x.
+        - build: linux-ppc64-stable
           os: ubuntu-latest
           rust: stable
-          target: s390x-unknown-linux-gnu
+          target: powerpc64-unknown-linux-gnu
         - build: linux-beta
           os: ubuntu-latest
           rust: beta

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,12 @@ jobs:
           target: i686-unknown-linux-gnu
         # big endian target (catches endianness bugs, e.g. in checksum calc).
         # powerpc64 is 64-bit big endian and emulates faster under QEMU than s390x.
+        # Reduced proptest cases as running under QEMU emulation is slow.
         - build: linux-ppc64-stable
           os: ubuntu-latest
           rust: stable
           target: powerpc64-unknown-linux-gnu
+          proptest_cases: 16
         - build: linux-beta
           os: ubuntu-latest
           rust: beta
@@ -77,6 +79,8 @@ jobs:
     - name: cross test
       if: matrix.target != ''
       run: cross test --target ${{ matrix.target }}
+      env:
+        PROPTEST_CASES: ${{ matrix.proptest_cases || '256' }}
 
     - name: cargo build --no-default-features
       if: matrix.target == ''
@@ -93,6 +97,8 @@ jobs:
     - name: cross test --no-default-features
       if: matrix.target != ''
       run: cross test --target ${{ matrix.target }} --no-default-features
+      env:
+        PROPTEST_CASES: ${{ matrix.proptest_cases || '256' }}
 
   no_std_build:
     name: no_std build

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+# Forward env vars into the cross build/test container. `PROPTEST_CASES` lets
+# CI reduce the number of proptest iterations for slow emulated targets.
+[build.env]
+passthrough = ["PROPTEST_CASES"]

--- a/etherparse/src/transport/udp_header.rs
+++ b/etherparse/src/transport/udp_header.rs
@@ -431,7 +431,7 @@ mod test {
                     ipv4.destination,
                     &base,
                     &payload
-                ).to_le());
+                ));
 
                 assert_eq!(
                     UdpHeader::with_ipv4_checksum(
@@ -533,7 +533,7 @@ mod test {
                     ipv4.destination,
                     &base,
                     &payload
-                ).to_le());
+                ));
 
                 // we now need to add a value that results in the value
                 // 0xffff (which will become 0 via the ones complement rule).
@@ -665,7 +665,7 @@ mod test {
                     ipv6.destination,
                     &base,
                     &payload
-                ).to_le());
+                ));
 
                 assert_eq!(
                     UdpHeader::with_ipv6_checksum(
@@ -769,7 +769,7 @@ mod test {
                     ipv6.destination,
                     &base,
                     &payload
-                ).to_le());
+                ));
 
                 assert_eq!(
                     UdpHeader::with_ipv6_checksum(
@@ -872,7 +872,7 @@ mod test {
                     ipv6.destination,
                     &base,
                     &payload
-                ).to_le());
+                ));
 
                 // we now need to add a value that results in the value
                 // 0xffff (which will become 0 via the ones complement rule).


### PR DESCRIPTION
Closes https://github.com/JulianSchmid/etherparse/issues/155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated CI test coverage by adding a new Linux big-endian target (`linux-ppc64-stable`) to the test matrix.
  * Adjusted CI test configuration to control `PROPTEST_CASES` per target, reducing iterations for emulated runs.
  * Improved UDP checksum-related test expectations for IPv4 and IPv6 scenarios to better validate checksum derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->