### PR TITLE
Publish coverage as gist badge instead of Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,9 +26,20 @@ jobs:
     - name: Determine coverage
       run: coverage/coverage.bash
       shell: bash
-    - name: Codecov
-      uses: codecov/codecov-action@v4
+    - name: Extract line coverage percentage
+      id: coverage
+      run: |
+        pct=$(jq '.data[0].totals.lines.percent' target/coverage/export_without_tests.json)
+        printf 'pct=%.2f\n' "$pct" >> "$GITHUB_OUTPUT"
+    - name: Update coverage badge gist
+      if: github.ref == 'refs/heads/master'
+      uses: schneegans/dynamic-badges-action@v1.7.0
       with:
-        files: target/coverage/export.lcov.txt
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+        auth: ${{ secrets.GIST_TOKEN }}
+        gistID: 8b0f5c110cd7a64899e13a45abcc98ff
+        filename: etherparse-coverage.json
+        label: coverage
+        message: ${{ steps.coverage.outputs.pct }}%
+        valColorRange: ${{ steps.coverage.outputs.pct }}
+        minColorRange: 0
+        maxColorRange: 100

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,10 +17,15 @@ jobs:
         toolchain: stable
         override: true
         components: llvm-tools-preview
-    - uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: cargo-binutils rustfilt
+    - name: Install coverage tools
+      # cargo-binutils 0.4.0 panics with clap 4.x ("no-default-features's
+      # ArgAction ..."), which makes every `cargo cov`/`cargo profdata` call
+      # abort and silently produces empty coverage output (0.00%). Pin to the
+      # last known-good release and use --locked so a future dependency
+      # release cannot reintroduce the breakage.
+      run: |
+        cargo install cargo-binutils --version 0.3.6 --locked
+        cargo install rustfilt --locked
     - name: Install jq
       run: sudo apt install jq
     - name: Determine coverage
@@ -29,7 +34,15 @@ jobs:
     - name: Extract line coverage percentage
       id: coverage
       run: |
-        pct=$(jq '.data[0].totals.lines.percent' target/coverage/export_without_tests.json)
+        set -euo pipefail
+        json=target/coverage/export_without_tests.json
+        if [ ! -s "$json" ]; then
+          echo "::error::coverage export '$json' is missing or empty" >&2
+          exit 1
+        fi
+        # `jq -e` exits non-zero when the value is null/absent, so a broken
+        # coverage run fails loudly instead of publishing a bogus 0.00% badge.
+        pct=$(jq -e '.data[0].totals.lines.percent' "$json")
         printf 'pct=%.2f\n' "$pct" >> "$GITHUB_OUTPUT"
     - name: Update coverage badge gist
       if: github.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![docs.rs](https://docs.rs/etherparse/badge.svg)](https://docs.rs/etherparse)
 [![Build Status Github](https://github.com/JulianSchmid/etherparse/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JulianSchmid/etherparse/actions/workflows/main.yml)
 [![Build Status Gitlab](https://gitlab.com/julian.schmid/etherparse/badges/master/pipeline.svg)](https://gitlab.com/julian.schmid/etherparse/-/commits/master)
+[![Coverage Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/JulianSchmid/8b0f5c110cd7a64899e13a45abcc98ff/raw/etherparse-coverage.json)](https://github.com/JulianSchmid/etherparse/actions/workflows/coverage.yml)
 
 # etherparse
 

--- a/README.tpl
+++ b/README.tpl
@@ -2,6 +2,7 @@
 [![docs.rs](https://docs.rs/etherparse/badge.svg)](https://docs.rs/etherparse)
 [![Build Status Github](https://github.com/JulianSchmid/etherparse/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JulianSchmid/etherparse/actions/workflows/main.yml)
 [![Build Status Gitlab](https://gitlab.com/julian.schmid/etherparse/badges/master/pipeline.svg)](https://gitlab.com/julian.schmid/etherparse/-/commits/master)
+[![Coverage Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/JulianSchmid/8b0f5c110cd7a64899e13a45abcc98ff/raw/etherparse-coverage.json)](https://github.com/JulianSchmid/etherparse/actions/workflows/coverage.yml)
 
 # {{crate}}
 

--- a/coverage/coverage.bash
+++ b/coverage/coverage.bash
@@ -111,4 +111,15 @@ cargo cov -- export --format=text \
     $(printf -- "-object %s " $(cat "${coverage_dir}/raw/filenames.txt")) \
   > "${coverage_dir}/export.json"
 
+cargo cov -- export --format=text \
+    --Xdemangler=rustfilt \
+    --ignore-filename-regex='/.cargo/registry' \
+    --ignore-filename-regex='/.rustup/toolchains' \
+    --ignore-filename-regex='/rustc' \
+    --ignore-filename-regex='etherparse/tests/' \
+    --ignore-filename-regex='etherparse_proptest_generators' \
+    "--instr-profile=${coverage_dir}/raw/merge.profdata" \
+    $(printf -- "-object %s " $(cat "${coverage_dir}/raw/filenames.txt")) \
+  > "${coverage_dir}/export_without_tests.json"
+
 popd


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a coverage status badge to the README and documentation template.
  * Coverage reporting now displays the percentage for production code, excluding test files.
  * The coverage badge is automatically updated with the latest percentage and corresponding status color.

* **Documentation**
  * Updated project documentation to include the new coverage status indicator alongside existing project badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->